### PR TITLE
Use dict for query input in Bugzilla.

### DIFF
--- a/clouseau/bugzilla.py
+++ b/clouseau/bugzilla.py
@@ -4,7 +4,12 @@
 
 import six
 import re
-from urllib.parse import urlencode
+try:
+    # Python 3
+    from urllib.parse import urlencode
+except ImportError:
+    # Python 2
+    from urllib import urlencode
 from .connection import (Connection, Query)
 from . import config
 
@@ -44,6 +49,9 @@ class Bugzilla(Connection):
                 self.bugids = [str(bugids)]
             elif isinstance(bugids, dict):
                 # Parameters to query string
+                if 'bug_id' in bugids and isinstance(bugids['bug_id'], list):
+                    # Special case for multiple bug_id
+                    bugids['bug_id'] = ','.join(map(str, bugids['bug_id']))
                 self.bugids = [urlencode(bugids), ]
             else:
                 self.bugids = list(map(str, bugids))

--- a/clouseau/bugzilla.py
+++ b/clouseau/bugzilla.py
@@ -4,6 +4,7 @@
 
 import six
 import re
+from urllib.parse import urlencode
 from .connection import (Connection, Query)
 from . import config
 
@@ -41,6 +42,9 @@ class Bugzilla(Connection):
                 self.bugids = [bugids]
             elif isinstance(bugids, int):
                 self.bugids = [str(bugids)]
+            elif isinstance(bugids, dict):
+                # Parameters to query string
+                self.bugids = [urlencode(bugids), ]
             else:
                 self.bugids = list(map(str, bugids))
             self.include_fields = include_fields

--- a/tests/test_bugzilla.py
+++ b/tests/test_bugzilla.py
@@ -46,7 +46,22 @@ class BugIDTest(unittest.TestCase):
             data[bug['id']] = bug
 
         bugs = {}
+
+        # Query string
         bugzilla.Bugzilla('bug_id=12345%2C12346&bug_id_type=anyexact&list_id=12958345&resolution=FIXED&query_format=advanced', bughandler=bughandler, bugdata=bugs).get_data().wait()
+
+        self.assertEqual(bugs[12345]['id'], 12345)
+        self.assertEqual(bugs[12346]['id'], 12346)
+
+        # Dict query
+        terms = {
+          'bug_id' : [12345, 12346],
+          'bug_id_type' : 'anyexact',
+          'list_id' : 12958345,
+          'resolution' : 'FIXED',
+          'query_format' : 'advanced',
+        }
+        bugzilla.Bugzilla(terms, bughandler=bughandler, bugdata=bugs).get_data().wait()
 
         self.assertEqual(bugs[12345]['id'], 12345)
         self.assertEqual(bugs[12346]['id'], 12346)
@@ -202,6 +217,34 @@ class BugAttachmentTest(unittest.TestCase):
 
         data = {}
         bugzilla.Bugzilla('bug_id=12345', bughandler=bughandler, bugdata=data, commenthandler=commenthandler, commentdata=data, historyhandler=historyhandler, historydata=data, attachmenthandler=attachmenthandler, attachmentdata=data).get_data().wait()
+
+        self.assertEqual(data['bug']['id'], 12345)
+        self.assertEqual(len(data['comment']), 19)
+        self.assertTrue(data['comment'][0]['text'].startswith(u'Steps to reproduce'))
+        self.assertEqual(len(data['history']['history']), 24)
+        self.assertEqual(len(data['attachment']), 1)
+        self.assertEqual(data['attachment'][0]['description'], 'Some patch.')
+        self.assertEqual(data['attachment'][0]['is_patch'], 1)
+        self.assertEqual(data['attachment'][0]['is_obsolete'], 1)
+
+    def test_search_dict(self):
+        def bughandler(bug, data):
+            data['bug'] = bug
+
+        def commenthandler(bug, bugid, data):
+            data['comment'] = bug['comments']
+
+        def historyhandler(bug, data):
+            data['history'] = bug
+
+        def attachmenthandler(bug, bugid, data):
+            data['attachment'] = bug
+
+        data = {}
+        query = {
+            'bug_id' : 12345,
+        }
+        bugzilla.Bugzilla(query, bughandler=bughandler, bugdata=data, commenthandler=commenthandler, commentdata=data, historyhandler=historyhandler, historydata=data, attachmenthandler=attachmenthandler, attachmentdata=data).get_data().wait()
 
         self.assertEqual(data['bug']['id'], 12345)
         self.assertEqual(len(data['comment']), 19)


### PR DESCRIPTION
Ease the request creation through Bugzilla

<pre>
    params = {
        'o1' : 'anywords',
        'v1' : 'approval-mozilla-beta',
        'f1' : 'flagtypes.name',
        'include_fields' : 'id',
    }
    b = Bugzilla(params, bughandler=bughandler)
    b.get_data().wait()
</pre>
