### PR TITLE
Find all modules in a crash report, not just a random one

### DIFF
--- a/clouseau/dll_addon_versions.py
+++ b/clouseau/dll_addon_versions.py
@@ -107,7 +107,6 @@ def get(signature, matching_mode, module, addon, product='Firefox', channel=['al
                     debug_id = m['debug_id']
                     versions[filename][dll_version] += 1
                     debug_ids[filename][debug_id] += 1
-                    break
 
             # if addon_version and dll_version and (addon_version == dll_version):
             #     data['match'].append(json['uuid'])


### PR DESCRIPTION
It is possible to search for more than one module:

```
usage: dll_addon_versions.py [-h] [-p PRODUCT] [-c CHANNEL [CHANNEL ...]] [-v]
                             [-V VERSIONS [VERSIONS ...]] [-l LIMIT]
                             [-m MODULE [MODULE ...]] [-a ADDON [ADDON ...]]
                             [-s START_DATE] [-S SIGNATURE] [-M MATCHING_MODE]
                             [-C] [-R RATIO]
  -m MODULE [MODULE ...], --module MODULE [MODULE ...]
                        the module name
```

But this feature is in fact broken. In every crash report it finds only one (random) module from the given list:

```
python -m clouseau.dll_addon_versions -S mozilla::net::CrashWithReason -m firefox.exe xul.dll -l 1
1 reports will be analyzed.
1 crash reports have been analyzed and the following versions have been found:
 - firefox.exe
   - 52.0.0.6148: 1
The following debug identifiers have been found:
 - firefox.exe
   - C365DA670FEB497B978C278BC0F9A6A32: 1
```

But both modules are present in the report:

```
python -m clouseau.dll_addon_versions -S mozilla::net::CrashWithReason -m firefox.exe -l 1
1 reports will be analyzed.
1 crash reports have been analyzed and the following versions have been found:
 - firefox.exe
   - 52.0.0.6148: 1
The following debug identifiers have been found:
 - firefox.exe
   - C365DA670FEB497B978C278BC0F9A6A32: 1

python -m clouseau.dll_addon_versions -S mozilla::net::CrashWithReason -m xul.dll -l 1
1 reports will be analyzed.
1 crash reports have been analyzed and the following versions have been found:
 - xul.dll
   - 52.0.0.6148: 1
The following debug identifiers have been found:
 - xul.dll
   - D2E3DBCC63EC41D18FF9344A12AB63F82: 1
```

After the fix:

```
python -m clouseau.dll_addon_versions -S mozilla::net::CrashWithReason -m firefox.exe xul.dll -l 1
1 reports will be analyzed.
1 crash reports have been analyzed and the following versions have been found:
 - xul.dll
   - 52.0.0.6148: 1
 - firefox.exe
   - 52.0.0.6148: 1
The following debug identifiers have been found:
 - xul.dll
   - D2E3DBCC63EC41D18FF9344A12AB63F82: 1
 - firefox.exe
   - C365DA670FEB497B978C278BC0F9A6A32: 1
```